### PR TITLE
fix: APIリクエストの入力検証を共通化する

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
+    "test": "vitest run",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix"
   },
@@ -22,12 +23,14 @@
     "nuxt": "^4.5.1",
     "scryfall-sdk": "^5.0.3",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.10"
   },
   "dependencies": {
     "@nuxtjs/i18n": "^10.6.0",
     "jszip": "^3.10.1",
-    "sharp": "^0.35.3"
+    "sharp": "^0.35.3",
+    "zod": "^4.4.3"
   },
   "packageManager": "pnpm@10.33.3"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       sharp:
         specifier: ^0.35.3
         version: 0.35.3(@types/node@24.5.2)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@iconify-json/lucide':
         specifier: ^1.2.121
@@ -70,6 +73,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.5.2)(vite@8.1.5(@types/node@24.5.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0))
 
 packages:
 
@@ -2555,6 +2561,12 @@ packages:
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
@@ -2870,6 +2882,35 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
 
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   '@vue-macros/common@3.1.4':
     resolution: {integrity: sha512-/5Fv+6DgIcM9ajY05ZmKBv+LMX1M9A0X+IUwDRVdt67ciw8OV9bvG2r34p3RiEadlsQybjhKPRKNXDC8Bp23cw==}
     engines: {node: '>=20.19.0'}
@@ -3079,6 +3120,10 @@ packages:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-kit@2.2.0:
     resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
     engines: {node: '>=20.19.0'}
@@ -3249,6 +3294,10 @@ packages:
 
   caniuse-lite@1.0.30001806:
     resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   change-case@5.4.4:
     resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
@@ -3858,6 +3907,10 @@ packages:
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   exsolve@1.1.0:
     resolution: {integrity: sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==}
@@ -5425,6 +5478,9 @@ packages:
     resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -5487,6 +5543,9 @@ packages:
   stable-hash-x@0.2.0:
     resolution: {integrity: sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==}
     engines: {node: '>=12.0.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
@@ -5611,6 +5670,9 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyclip@0.1.15:
     resolution: {integrity: sha512-uo33abH+Ays0xYaDysoBt494Hb3hsEczMpcC0MwFl773pazORx4fmvKhclhR1wonUbB6vvpRsvVMwnhfqeMc+A==}
     engines: {node: ^16.14.0 || >= 17.3.0}
@@ -5622,6 +5684,10 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -6035,6 +6101,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vue-bundle-renderer@2.3.1:
     resolution: {integrity: sha512-7F4LNMopUw5RgYWo4zCmVUHCc6aQRC6dCKHUYkM/n+fux4AUGdL1x6m5A515WWyFysRRN7cx3hBzVqoisfRfzw==}
 
@@ -6117,6 +6224,11 @@ packages:
   which@6.0.1:
     resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
     engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -8762,6 +8874,13 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/esrecurse@4.3.1': {}
 
   '@types/estree@1.0.8': {}
@@ -9105,6 +9224,47 @@ snapshots:
       vite: 8.1.5(@types/node@24.5.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0)
       vue: 3.5.40(typescript@6.0.3)
 
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@24.5.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.5(@types/node@24.5.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
   '@vue-macros/common@3.1.4(vue@3.5.40(typescript@6.0.3))':
     dependencies:
       '@vue/compiler-sfc': 3.5.40
@@ -9336,6 +9496,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  assertion-error@2.0.1: {}
+
   ast-kit@2.2.0:
     dependencies:
       '@babel/parser': 7.29.7
@@ -9495,6 +9657,8 @@ snapshots:
       caniuse-lite: 1.0.30001806
 
   caniuse-lite@1.0.30001806: {}
+
+  chai@6.2.2: {}
 
   change-case@5.4.4: {}
 
@@ -10157,6 +10321,8 @@ snapshots:
       onetime: 6.0.0
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
+
+  expect-type@1.4.0: {}
 
   exsolve@1.1.0: {}
 
@@ -12079,6 +12245,8 @@ snapshots:
 
   shell-quote@1.10.0: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -12130,6 +12298,8 @@ snapshots:
   srvx@0.12.5: {}
 
   stable-hash-x@0.2.0: {}
+
+  stackback@0.0.2: {}
 
   standard-as-callback@2.1.0: {}
 
@@ -12271,6 +12441,8 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyclip@0.1.15: {}
 
   tinyexec@1.2.4: {}
@@ -12279,6 +12451,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinyrainbow@3.1.1: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -12675,6 +12849,33 @@ snapshots:
       terser: 5.47.1
       yaml: 2.9.0
 
+  vitest@4.1.10(@types/node@24.5.2)(vite@8.1.5(@types/node@24.5.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@24.5.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.1.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.1.5(@types/node@24.5.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.5.2
+    transitivePeerDependencies:
+      - msw
+
   vue-bundle-renderer@2.3.1:
     dependencies:
       ufo: 1.6.4
@@ -12771,6 +12972,11 @@ snapshots:
   which@6.0.1:
     dependencies:
       isexe: 4.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/server/api/cards/byName.get.ts
+++ b/server/api/cards/byName.get.ts
@@ -1,20 +1,16 @@
 import {
-  DEFAULT_LANGUAGE_CODE,
-  isSupportedLanguageCode,
-} from '~/constants/languages'
+  cardByNameQuerySchema,
+  validateWith,
+} from '../../utils/validation'
 import { scryfallByName, scryfallBySet, scryfallSearch } from '../../utils/scryfall'
 
 export default defineEventHandler(async (event) => {
-  const query = getQuery(event)
-  const name = query.name as string
-  const langQuery = query.lang as string | undefined
+  const {
+    name,
+    lang: requestedLanguage,
+  } = await getValidatedQuery(event, validateWith(cardByNameQuerySchema))
 
-  const normalizedLanguage = langQuery?.toLowerCase()
-  const requestedLanguage = isSupportedLanguageCode(normalizedLanguage)
-    ? normalizedLanguage
-    : DEFAULT_LANGUAGE_CODE
-
-  const card = await scryfallByName(decodeURI(name), true)
+  const card = await scryfallByName(name, true)
 
   if (requestedLanguage === 'en') {
     return card

--- a/server/api/cards/byNames.post.ts
+++ b/server/api/cards/byNames.post.ts
@@ -1,19 +1,15 @@
 import type * as Scry from 'scryfall-sdk'
 import {
-  DEFAULT_LANGUAGE_CODE,
-  isSupportedLanguageCode,
-} from '~/constants/languages'
-import type { SupportedLanguageCode } from '~/constants/languages'
+  cardByNamesBodySchema,
+  validateWith,
+} from '../../utils/validation'
 import { scryfallByName, scryfallBySet } from '../../utils/scryfall'
 
 export default defineEventHandler(async (event) => {
-  const body = await readBody(event)
-  const cardNames = body.cardNames as string[]
-  const bodyLanguage = (body.language as string | undefined)?.toLowerCase()
-  const requestedLanguage: SupportedLanguageCode
-    = isSupportedLanguageCode(bodyLanguage)
-      ? bodyLanguage
-      : DEFAULT_LANGUAGE_CODE
+  const {
+    cardNames,
+    language: requestedLanguage,
+  } = await readValidatedBody(event, validateWith(cardByNamesBodySchema))
 
   const cards: Scry.Card[] = []
   const localizedCards: Scry.Card[] = []

--- a/server/api/cards/search/prints.get.ts
+++ b/server/api/cards/search/prints.get.ts
@@ -1,9 +1,14 @@
 import { scryfallSearch } from '../../../utils/scryfall'
+import {
+  cardPrintsQuerySchema,
+  validateWith,
+} from '../../../utils/validation'
 
 export default defineEventHandler(async (event) => {
-  const query = getQuery(event)
-  const id = query.id as string
-  const lang = query.lang as string
+  const { id, lang } = await getValidatedQuery(
+    event,
+    validateWith(cardPrintsQuerySchema),
+  )
 
   const cards = await scryfallSearch(`oracleid:${id} lang:${lang}`, {
     order: 'released',

--- a/server/api/download.post.ts
+++ b/server/api/download.post.ts
@@ -1,10 +1,16 @@
 import got from 'got'
+import {
+  downloadBodySchema,
+  validateWith,
+} from '../utils/validation'
 
 export default defineEventHandler(async (event) => {
   await new Promise(resolve => setTimeout(resolve, 100))
 
-  const body = await readBody(event)
-  const url = body.url as string
+  const { url } = await readValidatedBody(
+    event,
+    validateWith(downloadBodySchema),
+  )
 
   return await got.get(url).buffer()
 })

--- a/server/api/downloadTtsImages.post.ts
+++ b/server/api/downloadTtsImages.post.ts
@@ -1,5 +1,9 @@
 import got from 'got'
 import JSZip from 'jszip'
+import {
+  downloadTtsImagesBodySchema,
+  validateWith,
+} from '../utils/validation'
 
 const MERGE_ENDPOINT = 'https://tts-deck-server-production.up.railway.app/merge'
 const STACK_SIZE = 69
@@ -23,58 +27,25 @@ const chunkArray = <T>(items: T[], chunkSize: number): T[][] => {
   return chunks
 }
 
-type IncomingImage = { id?: unknown, imageUri?: unknown }
-type DownloadImageRequest = {
-  images?: Array<IncomingImage | null | undefined>
-  urls?: Array<unknown>
-  hiddenImage?: unknown
-}
-
 export default defineEventHandler(async (event) => {
-  const body = await readBody<DownloadImageRequest | undefined>(event) ?? {}
-  let images: Array<{ id?: string, imageUri: string }> = []
-  let hiddenImage: string | undefined
-
-  if (Array.isArray(body.images)) {
-    images = body.images
-      .filter((entry): entry is IncomingImage => typeof entry === 'object' && entry !== null)
-      .filter(entry => typeof entry.imageUri === 'string' && entry.imageUri.length > 0)
-      .map(entry => ({
-        id: typeof entry.id === 'string' ? entry.id : undefined,
-        imageUri: entry.imageUri as string,
-      }))
-  }
-
-  if (!images.length && Array.isArray(body.urls)) {
-    images = body.urls
-      .filter((url): url is string => typeof url === 'string' && url.length > 0)
-      .map((url, index) => ({ id: `image-${index}`, imageUri: url }))
-  }
-
-  if (!images.length) {
-    throw createError({ statusCode: 400, statusMessage: 'No images provided' })
-  }
-
-  if (typeof body.hiddenImage === 'string') {
-    const trimmed = body.hiddenImage.trim()
-    if (trimmed.length > 0) {
-      hiddenImage = trimmed
-    }
-  }
+  const body = await readValidatedBody(
+    event,
+    validateWith(downloadTtsImagesBodySchema),
+  )
+  const images = body.images ?? body.urls?.map((url, index) => ({
+    id: `image-${index}`,
+    imageUri: url,
+  })) ?? []
+  const { hiddenImage } = body
 
   if (hiddenImage) {
     console.info('[downloadTtsImages] hiddenImage payload (base64):', hiddenImage)
   }
 
-  const payload = images.map((entry: { id?: string, imageUri: string }, index: number): MergePayloadItem => {
-    const id = typeof entry.id === 'string' ? entry.id.trim() : ''
-    const imageUri = entry.imageUri.trim()
-
-    return {
-      id: id.length ? id : `image-${index}`,
-      imageUri,
-    }
-  })
+  const payload = images.map((entry, index): MergePayloadItem => ({
+    id: entry.id ?? `image-${index}`,
+    imageUri: entry.imageUri,
+  }))
 
   const chunks = chunkArray(payload, STACK_SIZE)
 

--- a/server/api/downloadZip.post.ts
+++ b/server/api/downloadZip.post.ts
@@ -1,11 +1,10 @@
-import { createError, setHeader } from 'h3'
+import { setHeader } from 'h3'
 import got from 'got'
 import JSZip from 'jszip'
-
-interface DownloadFileDescriptor {
-  url: string
-  fileName?: string
-}
+import {
+  downloadZipBodySchema,
+  validateWith,
+} from '../utils/validation'
 
 const sanitizeFileName = (name: string, index: number) => {
   const fallback = `card-${index + 1}.png`
@@ -28,15 +27,10 @@ const sanitizeFileName = (name: string, index: number) => {
 }
 
 export default defineEventHandler(async (event) => {
-  const body = await readBody(event)
-  const files = (body.files ?? []) as DownloadFileDescriptor[]
-
-  if (!Array.isArray(files) || files.length === 0) {
-    throw createError({
-      statusCode: 400,
-      statusMessage: 'Request must include files.',
-    })
-  }
+  const { files } = await readValidatedBody(
+    event,
+    validateWith(downloadZipBodySchema),
+  )
 
   const zip = new JSZip()
 

--- a/server/utils/validation.test.ts
+++ b/server/utils/validation.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest'
+import {
+  cardByNameQuerySchema,
+  cardByNamesBodySchema,
+  cardPrintsQuerySchema,
+  downloadBodySchema,
+  downloadTtsImagesBodySchema,
+  downloadZipBodySchema,
+  MAX_CARD_NAMES,
+  MAX_DOWNLOAD_FILES,
+  MAX_TTS_IMAGES,
+} from './validation'
+
+describe('cardByNameQuerySchema', () => {
+  it('accepts Scryfall card names with Unicode and punctuation', () => {
+    expect(cardByNameQuerySchema.parse({
+      name: '  Who // What // When // Where // Why?  ',
+    })).toEqual({
+      name: 'Who // What // When // Where // Why?',
+      lang: 'en',
+    })
+  })
+
+  it('normalizes a supported language code', () => {
+    expect(cardByNameQuerySchema.parse({ name: '島', lang: 'PT' })).toEqual({
+      name: '島',
+      lang: 'pt',
+    })
+  })
+
+  it.each([
+    { name: '' },
+    { name: ['Black Lotus'] },
+    { name: 'Black Lotus', lang: 'xx' },
+    { name: 'Black Lotus', lang: ['en'] },
+  ])('rejects malformed input: %o', (input) => {
+    expect(cardByNameQuerySchema.safeParse(input).success).toBe(false)
+  })
+})
+
+describe('cardByNamesBodySchema', () => {
+  it('normalizes names and applies the default language', () => {
+    expect(cardByNamesBodySchema.parse({
+      cardNames: [' Black Lotus ', 'Fire // Ice'],
+    })).toEqual({
+      cardNames: ['Black Lotus', 'Fire // Ice'],
+      language: 'en',
+    })
+  })
+
+  it.each([
+    { cardNames: 'Black Lotus' },
+    { cardNames: [] },
+    { cardNames: [''] },
+    { cardNames: ['Black Lotus'], extra: true },
+    { cardNames: Array.from({ length: MAX_CARD_NAMES + 1 }, () => 'Island') },
+  ])('rejects malformed or excessive input', (input) => {
+    expect(cardByNamesBodySchema.safeParse(input).success).toBe(false)
+  })
+})
+
+describe('cardPrintsQuerySchema', () => {
+  const oracleId = '0000579f-7b35-4ed3-b44c-db2a538066fe'
+
+  it('accepts a Scryfall Oracle ID and supported language', () => {
+    expect(cardPrintsQuerySchema.parse({ id: oracleId.toUpperCase(), lang: 'FR' })).toEqual({
+      id: oracleId,
+      lang: 'fr',
+    })
+  })
+
+  it.each([
+    { id: 'not-a-uuid', lang: 'en' },
+    { id: `${oracleId} lang:ja`, lang: 'en' },
+    { id: oracleId, lang: 'zxx' },
+  ])('rejects values that cannot be Scryfall search filters', (input) => {
+    expect(cardPrintsQuerySchema.safeParse(input).success).toBe(false)
+  })
+})
+
+describe('downloadBodySchema', () => {
+  it.each([
+    'https://cards.scryfall.io/normal/front/example.jpg',
+    'http://example.test/image.png',
+  ])('accepts an HTTP(S) URL', (url) => {
+    expect(downloadBodySchema.parse({ url })).toEqual({ url })
+  })
+
+  it.each([
+    'file:///etc/passwd',
+    'data:image/png;base64,aGVsbG8=',
+    'not a URL',
+  ])('rejects a non-HTTP URL', (url) => {
+    expect(downloadBodySchema.safeParse({ url }).success).toBe(false)
+  })
+})
+
+describe('downloadZipBodySchema', () => {
+  it('normalizes an optional file name', () => {
+    expect(downloadZipBodySchema.parse({
+      files: [{ url: 'https://example.test/card.png', fileName: '  Card  ' }],
+    })).toEqual({
+      files: [{ url: 'https://example.test/card.png', fileName: 'Card' }],
+    })
+  })
+
+  it.each([
+    { files: [] },
+    { files: [null] },
+    {
+      files: Array.from({ length: MAX_DOWNLOAD_FILES + 1 }, () => ({
+        url: 'https://example.test/card.png',
+      })),
+    },
+  ])('rejects malformed or excessive file lists', (input) => {
+    expect(downloadZipBodySchema.safeParse(input).success).toBe(false)
+  })
+})
+
+describe('downloadTtsImagesBodySchema', () => {
+  it('accepts the current image descriptor format', () => {
+    expect(downloadTtsImagesBodySchema.parse({
+      images: [{ id: ' card-1 ', imageUri: 'https://example.test/card.png' }],
+      hiddenImage: 'data:image/png;base64,aGVsbG8=',
+    })).toEqual({
+      images: [{ id: 'card-1', imageUri: 'https://example.test/card.png' }],
+      hiddenImage: 'data:image/png;base64,aGVsbG8=',
+    })
+  })
+
+  it('keeps accepting the legacy URL format', () => {
+    expect(downloadTtsImagesBodySchema.parse({
+      urls: ['https://example.test/card.png'],
+    })).toEqual({
+      urls: ['https://example.test/card.png'],
+    })
+  })
+
+  it.each([
+    {},
+    { images: [], urls: ['https://example.test/card.png'] },
+    { images: [{ imageUri: '' }] },
+    { urls: ['file:///etc/passwd'] },
+    { images: [{ imageUri: 'https://example.test/card.png' }], hiddenImage: 'data:text/plain;base64,aGVsbG8=' },
+    {
+      urls: Array.from({ length: MAX_TTS_IMAGES + 1 }, () => 'https://example.test/card.png'),
+    },
+  ])('rejects malformed, ambiguous, or excessive image input', (input) => {
+    expect(downloadTtsImagesBodySchema.safeParse(input).success).toBe(false)
+  })
+})

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -1,0 +1,164 @@
+import { z } from 'zod'
+import { DEFAULT_LANGUAGE_CODE } from '~/constants/languages'
+
+export const MAX_CARD_NAME_LENGTH = 1024
+export const MAX_CARD_NAMES = 100
+export const MAX_URL_LENGTH = 2048
+export const MAX_FILE_NAME_LENGTH = 255
+export const MAX_DOWNLOAD_FILES = 100
+export const MAX_TTS_IMAGES = 500
+export const MAX_IMAGE_ID_LENGTH = 128
+export const MAX_HIDDEN_IMAGE_DATA_URL_LENGTH = 6 * 1024 * 1024
+
+// https://scryfall.com/docs/api/languages
+export const SCRYFALL_LANGUAGE_CODES = [
+  'en',
+  'es',
+  'fr',
+  'de',
+  'it',
+  'pt',
+  'ja',
+  'ko',
+  'ru',
+  'zhs',
+  'zht',
+  'he',
+  'la',
+  'grc',
+  'ar',
+  'sa',
+  'ph',
+] as const
+
+type ScryfallLanguageCode = (typeof SCRYFALL_LANGUAGE_CODES)[number]
+
+const SCRYFALL_LANGUAGE_CODE_SET = new Set<string>(SCRYFALL_LANGUAGE_CODES)
+
+const IMAGE_DATA_URL_PATTERN = /^data:image\/(?:jpeg|png);base64,[A-Za-z0-9+/]+={0,2}$/
+
+const trimmedString = (field: string, maxLength: number) => z
+  .string({ error: `${field} must be a string` })
+  .trim()
+  .min(1, `${field} must not be empty`)
+  .max(maxLength, `${field} is too long`)
+
+const optionalTrimmedString = (field: string, maxLength: number) => z
+  .string({ error: `${field} must be a string` })
+  .trim()
+  .max(maxLength, `${field} is too long`)
+  .transform(value => value || undefined)
+  .optional()
+
+const supportedLanguageSchema = z
+  .string({ error: 'language must be a string' })
+  .trim()
+  .toLowerCase()
+  .refine(
+    (value): value is ScryfallLanguageCode => SCRYFALL_LANGUAGE_CODE_SET.has(value),
+    'Unsupported Scryfall language code',
+  )
+
+const oracleIdSchema = z
+  .string({ error: 'id must be a string' })
+  .trim()
+  .toLowerCase()
+  .pipe(z.uuid('id must be a valid Scryfall Oracle ID'))
+
+const httpUrlSchema = z
+  .string({ error: 'URL must be a string' })
+  .trim()
+  .max(MAX_URL_LENGTH, 'URL is too long')
+  .url('URL must be valid')
+  .refine((value) => {
+    try {
+      const protocol = new URL(value).protocol
+      return protocol === 'http:' || protocol === 'https:'
+    }
+    catch {
+      return false
+    }
+  }, 'URL must use HTTP or HTTPS')
+
+const fileNameSchema = optionalTrimmedString('fileName', MAX_FILE_NAME_LENGTH)
+
+const hiddenImageSchema = z
+  .string({ error: 'hiddenImage must be a string' })
+  .trim()
+  .min(1, 'hiddenImage must not be empty')
+  .max(MAX_HIDDEN_IMAGE_DATA_URL_LENGTH, 'hiddenImage is too large')
+  .regex(IMAGE_DATA_URL_PATTERN, 'hiddenImage must be a PNG or JPEG data URL')
+  .optional()
+
+export const cardByNameQuerySchema = z.object({
+  name: trimmedString('name', MAX_CARD_NAME_LENGTH),
+  lang: supportedLanguageSchema.optional().default(DEFAULT_LANGUAGE_CODE),
+}).strict()
+
+export const cardByNamesBodySchema = z.object({
+  cardNames: z
+    .array(trimmedString('cardName', MAX_CARD_NAME_LENGTH))
+    .min(1, 'cardNames must contain at least one card name')
+    .max(MAX_CARD_NAMES, `cardNames must contain at most ${MAX_CARD_NAMES} entries`),
+  language: supportedLanguageSchema.optional().default(DEFAULT_LANGUAGE_CODE),
+}).strict()
+
+export const cardPrintsQuerySchema = z.object({
+  id: oracleIdSchema,
+  lang: supportedLanguageSchema,
+}).strict()
+
+export const downloadBodySchema = z.object({
+  url: httpUrlSchema,
+}).strict()
+
+const downloadFileSchema = z.object({
+  url: httpUrlSchema,
+  fileName: fileNameSchema,
+}).strict()
+
+export const downloadZipBodySchema = z.object({
+  files: z
+    .array(downloadFileSchema)
+    .min(1, 'files must contain at least one file')
+    .max(MAX_DOWNLOAD_FILES, `files must contain at most ${MAX_DOWNLOAD_FILES} entries`),
+}).strict()
+
+const downloadImageSchema = z.object({
+  id: optionalTrimmedString('id', MAX_IMAGE_ID_LENGTH),
+  imageUri: httpUrlSchema,
+}).strict()
+
+export const downloadTtsImagesBodySchema = z.object({
+  images: z
+    .array(downloadImageSchema)
+    .min(1, 'images must contain at least one image')
+    .max(MAX_TTS_IMAGES, `images must contain at most ${MAX_TTS_IMAGES} entries`)
+    .optional(),
+  urls: z
+    .array(httpUrlSchema)
+    .min(1, 'urls must contain at least one URL')
+    .max(MAX_TTS_IMAGES, `urls must contain at most ${MAX_TTS_IMAGES} entries`)
+    .optional(),
+  hiddenImage: hiddenImageSchema,
+}).strict().superRefine((body, context) => {
+  if (!body.images && !body.urls) {
+    context.addIssue({
+      code: 'custom',
+      path: ['images'],
+      message: 'Either images or urls must be provided',
+    })
+  }
+
+  if (body.images && body.urls) {
+    context.addIssue({
+      code: 'custom',
+      path: ['urls'],
+      message: 'Provide either images or urls, not both',
+    })
+  }
+})
+
+export const validateWith = <Output>(schema: z.ZodType<Output>) => {
+  return (input: unknown): Output => schema.parse(input)
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { fileURLToPath } from 'node:url'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '~': fileURLToPath(new URL('./app', import.meta.url)),
+    },
+  },
+  test: {
+    include: ['server/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
## Summary

- Zodによる共通入力スキーマを追加し、対象6 APIでクエリ・JSON bodyを実行時検証
- カード名、Oracle ID、言語コード、HTTP(S) URL、ファイル名を正規化し、文字列長・配列件数・画像data URLサイズを制限
- 不正入力をH3のValidation Error（400）へ統一し、API境界の型アサーションを削減
- Vitestを導入し、正常系・型不正・欠損・検索式混入・上限超過を33ケースで検証

## Scryfall compatibility

- カード名はUnicodeや `//` などの記号を許容し、空文字と1024文字超過のみを拒否
- 言語コードは[Scryfall公式一覧](https://scryfall.com/docs/api/languages)の17コードを許容
- Scryfall検索式に埋め込むOracle IDはUUIDとして検証してから使用

## Verification

- `pnpm test`（33 tests passed）
- `pnpm lint`（errors 0、既存Vueファイルのwarnings 5）
- `pnpm build`
- 本番ビルドをローカル起動し、トップ画面200、不正入力400、`Black Lotus`の取得200、公式言語コード `pt` 指定200を確認

Closes #383
