### PR TITLE
fix: ZIP生成時のリソース使用量を制限する

### DIFF
--- a/server/api/downloadTtsImages.post.ts
+++ b/server/api/downloadTtsImages.post.ts
@@ -1,5 +1,14 @@
 import got from 'got'
+import { sendStream } from 'h3'
 import JSZip from 'jszip'
+import {
+  addToSizeBudget,
+  createTimedZipStream,
+  DownloadSizeLimitError,
+  MAX_TTS_MERGED_IMAGE_BYTES,
+  MAX_TTS_MERGED_TOTAL_BYTES,
+  readLimitedBufferResponse,
+} from '../utils/downloadResources'
 import {
   downloadTtsImagesBodySchema,
   validateWith,
@@ -49,7 +58,8 @@ export default defineEventHandler(async (event) => {
 
   const chunks = chunkArray(payload, STACK_SIZE)
 
-  const mergedChunks: Array<{ buffer: Buffer, contentType: string, fileName: string }> = []
+  const mergedChunks: Array<{ buffer: Uint8Array, contentType: string, fileName: string }> = []
+  let totalMergedBytes = 0
 
   for (const [chunkIndex, chunk] of chunks.entries()) {
     try {
@@ -57,14 +67,29 @@ export default defineEventHandler(async (event) => {
       if (hiddenImage) {
         requestPayload.hiddenImage = hiddenImage
       }
-      const response = await got.post(MERGE_ENDPOINT, {
-        json: requestPayload,
-        responseType: 'buffer',
-        timeout: {
-          request: 60000,
-        },
-      })
-      const contentType = response.headers['content-type'] ?? 'image/png'
+      const response = await readLimitedBufferResponse(
+        signal => got.post(MERGE_ENDPOINT, {
+          json: requestPayload,
+          responseType: 'buffer',
+          retry: { limit: 0 },
+          signal,
+          timeout: {
+            connect: 5000,
+            response: 60000,
+            request: 60000,
+          },
+        }),
+        MAX_TTS_MERGED_IMAGE_BYTES,
+      )
+      const responseContentType = response.headers['content-type']
+      const contentType = Array.isArray(responseContentType)
+        ? responseContentType[0] ?? 'image/png'
+        : responseContentType ?? 'image/png'
+      totalMergedBytes = addToSizeBudget(
+        totalMergedBytes,
+        response.rawBody.length,
+        MAX_TTS_MERGED_TOTAL_BYTES,
+      )
 
       mergedChunks.push({
         buffer: response.rawBody,
@@ -73,6 +98,13 @@ export default defineEventHandler(async (event) => {
       })
     }
     catch (error) {
+      if (error instanceof DownloadSizeLimitError) {
+        throw createError({
+          statusCode: 413,
+          statusMessage: 'Merged images exceed the size limit',
+          cause: error,
+        })
+      }
       throw createError({ statusCode: 502, statusMessage: 'Failed to merge images', cause: error })
     }
   }
@@ -93,9 +125,8 @@ export default defineEventHandler(async (event) => {
     zip.file(fileName, buffer)
   }
 
-  const archive = await zip.generateAsync({ type: 'nodebuffer' })
   setHeader(event, 'Content-Type', ZIP_CONTENT_TYPE)
   setHeader(event, 'Content-Disposition', `attachment; filename="${ZIP_FILE_NAME}"`)
 
-  return archive
+  return sendStream(event, createTimedZipStream(zip))
 })

--- a/server/api/downloadZip.post.ts
+++ b/server/api/downloadZip.post.ts
@@ -1,5 +1,14 @@
-import { setHeader } from 'h3'
+import { createError, sendStream, setHeader } from 'h3'
 import JSZip from 'jszip'
+import {
+  addToSizeBudget,
+  createTimedZipStream,
+  DownloadSizeLimitError,
+  makeUniqueFileNames,
+  mapWithConcurrency,
+  MAX_CONCURRENT_IMAGE_DOWNLOADS,
+  MAX_ZIP_SOURCE_BYTES,
+} from '../utils/downloadResources'
 import {
   downloadZipBodySchema,
   validateWith,
@@ -33,19 +42,47 @@ export default defineEventHandler(async (event) => {
   )
 
   const zip = new JSZip()
-
-  await Promise.all(
-    files.map(async ({ url, fileName }, index) => {
-      const buffer = await downloadScryfallImage(url)
-      const safeName = sanitizeFileName(fileName ?? '', index)
-      zip.file(safeName, buffer)
-    }),
+  const fileNames = makeUniqueFileNames(
+    files.map(({ fileName }, index) => sanitizeFileName(fileName ?? '', index)),
   )
+  let totalSourceBytes = 0
 
-  const output = await zip.generateAsync({ type: 'nodebuffer' })
+  try {
+    const downloadedFiles = await mapWithConcurrency(
+      files,
+      MAX_CONCURRENT_IMAGE_DOWNLOADS,
+      async ({ url }, index) => {
+        const buffer = await downloadScryfallImage(url)
+        totalSourceBytes = addToSizeBudget(
+          totalSourceBytes,
+          buffer.length,
+          MAX_ZIP_SOURCE_BYTES,
+        )
+        return { buffer, fileName: fileNames[index] }
+      },
+    )
+
+    for (const { buffer, fileName } of downloadedFiles) {
+      if (fileName) zip.file(fileName, buffer)
+    }
+  }
+  catch (error) {
+    if (error instanceof DownloadSizeLimitError) {
+      throw createError({
+        statusCode: 413,
+        statusMessage: 'Downloaded images exceed the size limit',
+        cause: error,
+      })
+    }
+    throw createError({
+      statusCode: 502,
+      statusMessage: 'Failed to download card images',
+      cause: error,
+    })
+  }
 
   setHeader(event, 'Content-Type', 'application/zip')
   setHeader(event, 'Content-Disposition', 'attachment; filename="cards.zip"')
 
-  return output
+  return sendStream(event, createTimedZipStream(zip))
 })

--- a/server/utils/downloadResources.test.ts
+++ b/server/utils/downloadResources.test.ts
@@ -1,0 +1,127 @@
+import { Buffer } from 'node:buffer'
+import JSZip from 'jszip'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  addToSizeBudget,
+  createTimedZipStream,
+  DownloadSizeLimitError,
+  makeUniqueFileNames,
+  mapWithConcurrency,
+  readLimitedBufferResponse,
+} from './downloadResources'
+import type { ProgressRequest } from './downloadResources'
+
+const createProgressRequest = <Response extends { rawBody: Buffer }>(
+  response: Response,
+  progressEvents: Array<{ transferred: number, total?: number }> = [],
+) => {
+  const request = Promise.resolve(response) as ProgressRequest<Response>
+  request.on = (event, listener) => {
+    if (event !== 'downloadProgress') return request
+    for (const progress of progressEvents) listener(progress)
+    return request
+  }
+  return request
+}
+
+describe('readLimitedBufferResponse', () => {
+  it('returns a response within the byte limit', async () => {
+    const response = { rawBody: Buffer.alloc(10) }
+
+    await expect(readLimitedBufferResponse(
+      () => createProgressRequest(response, [{ transferred: 10, total: 10 }]),
+      10,
+    )).resolves.toBe(response)
+  })
+
+  it('aborts when Content-Length exceeds the byte limit', async () => {
+    let signal: AbortSignal | undefined
+
+    await expect(readLimitedBufferResponse(
+      (requestSignal) => {
+        signal = requestSignal
+        return createProgressRequest(
+          { rawBody: Buffer.alloc(0) },
+          [{ transferred: 0, total: 11 }],
+        )
+      },
+      10,
+    )).rejects.toBeInstanceOf(DownloadSizeLimitError)
+    expect(signal?.aborted).toBe(true)
+  })
+
+  it('rejects a response whose actual body exceeds the byte limit', async () => {
+    await expect(readLimitedBufferResponse(
+      () => createProgressRequest({ rawBody: Buffer.alloc(11) }),
+      10,
+    )).rejects.toBeInstanceOf(DownloadSizeLimitError)
+  })
+})
+
+describe('addToSizeBudget', () => {
+  it('tracks bytes within the total budget', () => {
+    expect(addToSizeBudget(4, 6, 10)).toBe(10)
+  })
+
+  it('rejects bytes above the total budget', () => {
+    expect(() => addToSizeBudget(5, 6, 10)).toThrow(DownloadSizeLimitError)
+  })
+})
+
+describe('mapWithConcurrency', () => {
+  it('preserves result order while limiting active tasks', async () => {
+    let activeTasks = 0
+    let maxActiveTasks = 0
+
+    const results = await mapWithConcurrency([1, 2, 3, 4, 5, 6], 2, async (item) => {
+      activeTasks += 1
+      maxActiveTasks = Math.max(maxActiveTasks, activeTasks)
+      await new Promise(resolve => setTimeout(resolve, 1))
+      activeTasks -= 1
+      return item * 2
+    })
+
+    expect(results).toEqual([2, 4, 6, 8, 10, 12])
+    expect(maxActiveTasks).toBe(2)
+  })
+
+  it('rejects an invalid concurrency value', async () => {
+    await expect(mapWithConcurrency([], 0, vi.fn())).rejects.toThrow(
+      'concurrency must be a positive integer',
+    )
+  })
+})
+
+describe('makeUniqueFileNames', () => {
+  it('adds deterministic suffixes without overwriting existing names', () => {
+    expect(makeUniqueFileNames([
+      'card.png',
+      'card-2.png',
+      'card.png',
+      'CARD.PNG',
+    ])).toEqual([
+      'card.png',
+      'card-2.png',
+      'card-3.png',
+      'CARD-4.PNG',
+    ])
+  })
+})
+
+describe('createTimedZipStream', () => {
+  it('streams a valid ZIP without creating the final archive buffer first', async () => {
+    const zip = new JSZip()
+    zip.file('card.png', Buffer.from('image'))
+
+    const chunks: Buffer[] = []
+    const stream = createTimedZipStream(zip, 1000)
+    await new Promise<void>((resolve, reject) => {
+      stream.on('data', chunk => chunks.push(Buffer.from(chunk)))
+      stream.on('end', resolve)
+      stream.on('error', reject)
+    })
+
+    const archive = await JSZip.loadAsync(Buffer.concat(chunks))
+    await expect(archive.file('card.png')?.async('string')).resolves.toBe('image')
+  })
+})

--- a/server/utils/downloadResources.ts
+++ b/server/utils/downloadResources.ts
@@ -1,0 +1,166 @@
+import type { Readable } from 'node:stream'
+import type JSZip from 'jszip'
+
+const MEBIBYTE = 1024 * 1024
+
+export const MAX_CONCURRENT_IMAGE_DOWNLOADS = 4
+export const MAX_ZIP_IMAGE_BYTES = 15 * MEBIBYTE
+export const MAX_ZIP_SOURCE_BYTES = 200 * MEBIBYTE
+export const MAX_TTS_MERGED_IMAGE_BYTES = 100 * MEBIBYTE
+export const MAX_TTS_MERGED_TOTAL_BYTES = 300 * MEBIBYTE
+export const ZIP_STREAM_TIMEOUT_MS = 120_000
+
+type BufferResponse = {
+  rawBody: Uint8Array
+}
+
+type DownloadProgress = {
+  transferred: number
+  total?: number
+}
+
+/* eslint-disable no-unused-vars -- callback names document these utility contracts */
+type DownloadProgressListener = (progress: DownloadProgress) => void
+type DownloadProgressHandler<Response extends BufferResponse> = (
+  event: 'downloadProgress',
+  listener: DownloadProgressListener,
+) => unknown
+type ProgressRequestFactory<Response extends BufferResponse> = (
+  signal: AbortSignal,
+) => ProgressRequest<Response>
+type AsyncMapper<Item, Result> = (
+  item: Item,
+  index: number,
+) => Promise<Result>
+/* eslint-enable no-unused-vars */
+
+export type ProgressRequest<Response extends BufferResponse> = Promise<Response> & {
+  on: DownloadProgressHandler<Response>
+}
+
+export class DownloadSizeLimitError extends Error {
+  constructor(limitBytes: number) {
+    super(`Download exceeds the ${limitBytes} byte limit`)
+    this.name = 'DownloadSizeLimitError'
+  }
+}
+
+export const readLimitedBufferResponse = async <Response extends BufferResponse>(
+  createRequest: ProgressRequestFactory<Response>,
+  maxBytes: number,
+) => {
+  const controller = new AbortController()
+  let limitExceeded = false
+  const request = createRequest(controller.signal)
+
+  request.on('downloadProgress', ({ transferred, total }) => {
+    if (transferred > maxBytes || (total !== undefined && total > maxBytes)) {
+      limitExceeded = true
+      controller.abort()
+    }
+  })
+
+  try {
+    const response = await request
+    if (limitExceeded || response.rawBody.length > maxBytes) {
+      throw new DownloadSizeLimitError(maxBytes)
+    }
+    return response
+  }
+  catch (error) {
+    if (limitExceeded) {
+      throw new DownloadSizeLimitError(maxBytes)
+    }
+    throw error
+  }
+}
+
+export const addToSizeBudget = (
+  currentBytes: number,
+  addedBytes: number,
+  maxBytes: number,
+) => {
+  const nextBytes = currentBytes + addedBytes
+  if (nextBytes > maxBytes) {
+    throw new DownloadSizeLimitError(maxBytes)
+  }
+  return nextBytes
+}
+
+export const mapWithConcurrency = async <Item, Result>(
+  items: readonly Item[],
+  concurrency: number,
+  mapper: AsyncMapper<Item, Result>,
+) => {
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new Error('concurrency must be a positive integer')
+  }
+
+  const results = new Array<Result>(items.length)
+  let nextIndex = 0
+
+  const worker = async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex
+      nextIndex += 1
+      const item = items[index] as Item
+      results[index] = await mapper(item, index)
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.min(concurrency, items.length) },
+    () => worker(),
+  )
+  await Promise.all(workers)
+
+  return results
+}
+
+const splitExtension = (fileName: string) => {
+  const extensionIndex = fileName.lastIndexOf('.')
+  if (extensionIndex <= 0) return { base: fileName, extension: '' }
+
+  return {
+    base: fileName.slice(0, extensionIndex),
+    extension: fileName.slice(extensionIndex),
+  }
+}
+
+export const makeUniqueFileNames = (fileNames: readonly string[]) => {
+  const usedNames = new Set<string>()
+
+  return fileNames.map((fileName) => {
+    const { base, extension } = splitExtension(fileName)
+    let candidate = fileName
+    let suffix = 2
+
+    while (usedNames.has(candidate.toLowerCase())) {
+      candidate = `${base}-${suffix}${extension}`
+      suffix += 1
+    }
+
+    usedNames.add(candidate.toLowerCase())
+    return candidate
+  })
+}
+
+export const createTimedZipStream = (
+  zip: JSZip,
+  timeoutMs = ZIP_STREAM_TIMEOUT_MS,
+) => {
+  const stream = zip.generateNodeStream({
+    type: 'nodebuffer',
+    streamFiles: true,
+  }) as Readable
+  const timer = setTimeout(() => {
+    stream.destroy(new Error('ZIP generation timed out'))
+  }, timeoutMs)
+  const clearTimer = () => clearTimeout(timer)
+
+  stream.once('end', clearTimer)
+  stream.once('error', clearTimer)
+  stream.once('close', clearTimer)
+
+  return stream
+}

--- a/server/utils/scryfallImageDownload.test.ts
+++ b/server/utils/scryfallImageDownload.test.ts
@@ -3,6 +3,10 @@ import type { LookupFunction } from 'node:net'
 import { Buffer } from 'node:buffer'
 import { describe, expect, it, vi } from 'vitest'
 import {
+  DownloadSizeLimitError,
+  MAX_ZIP_IMAGE_BYTES,
+} from './downloadResources'
+import {
   createSafeDnsLookup,
   downloadScryfallImage,
   isPublicIpAddress,
@@ -106,7 +110,7 @@ describe('downloadScryfallImage', () => {
 
     await expect(downloadScryfallImage(
       'https://cards.scryfall.io/large/front/card.jpg',
-      request,
+      { request },
     )).resolves.toBe(image)
 
     expect(request).toHaveBeenCalledWith(
@@ -118,6 +122,7 @@ describe('downloadScryfallImage', () => {
         retry: { limit: 0 },
         timeout: SCRYFALL_IMAGE_DOWNLOAD_TIMEOUT,
       }),
+      MAX_ZIP_IMAGE_BYTES,
     )
   })
 
@@ -129,8 +134,20 @@ describe('downloadScryfallImage', () => {
 
     await expect(downloadScryfallImage(
       'https://cards.scryfall.io/large/front/card.jpg',
-      request,
+      { request },
     )).rejects.toThrow('Redirect responses are not allowed')
+  })
+
+  it('rejects images above the configured byte limit', async () => {
+    const request = vi.fn(async () => ({
+      statusCode: 200,
+      rawBody: Buffer.alloc(11),
+    }))
+
+    await expect(downloadScryfallImage(
+      'https://cards.scryfall.io/large/front/card.jpg',
+      { maxBytes: 10, request },
+    )).rejects.toBeInstanceOf(DownloadSizeLimitError)
   })
 
   it('revalidates the URL before making a request', async () => {
@@ -138,7 +155,7 @@ describe('downloadScryfallImage', () => {
 
     await expect(downloadScryfallImage(
       'https://example.test/card.jpg',
-      request,
+      { request },
     )).rejects.toThrow('host is not allowed')
     expect(request).not.toHaveBeenCalled()
   })

--- a/server/utils/scryfallImageDownload.ts
+++ b/server/utils/scryfallImageDownload.ts
@@ -3,6 +3,11 @@ import { lookup } from 'node:dns/promises'
 import type { LookupFunction } from 'node:net'
 import got from 'got'
 import ipaddr from 'ipaddr.js'
+import {
+  DownloadSizeLimitError,
+  MAX_ZIP_IMAGE_BYTES,
+  readLimitedBufferResponse,
+} from './downloadResources'
 import { parseScryfallImageUrl } from './scryfallImageUrl'
 
 export const SCRYFALL_IMAGE_DOWNLOAD_TIMEOUT = {
@@ -15,7 +20,7 @@ export const SCRYFALL_IMAGE_DOWNLOAD_TIMEOUT = {
 
 type ImageResponse = {
   statusCode: number
-  rawBody: Buffer
+  rawBody: Uint8Array
 }
 
 type ImageRequestOptions = {
@@ -42,8 +47,16 @@ export type ResolveHostname = typeof resolveHostname
 const fetchImage = async (
   url: URL,
   options: ImageRequestOptions,
+  maxBytes: number,
 ): Promise<ImageResponse> => {
-  return await got.get(url, options)
+  return await readLimitedBufferResponse(
+    signal => got.get(url, {
+      ...options,
+      responseType: 'buffer',
+      signal,
+    }),
+    maxBytes,
+  )
 }
 
 export type FetchImage = typeof fetchImage
@@ -101,8 +114,15 @@ export const createSafeDnsLookup = (
 
 export const downloadScryfallImage = async (
   input: string,
-  request: FetchImage = fetchImage,
+  options: {
+    maxBytes?: number
+    request?: FetchImage
+  } = {},
 ) => {
+  const {
+    maxBytes = MAX_ZIP_IMAGE_BYTES,
+    request = fetchImage,
+  } = options
   const url = parseScryfallImageUrl(input)
   const response = await request(url, {
     dnsLookup: createSafeDnsLookup(),
@@ -116,10 +136,14 @@ export const downloadScryfallImage = async (
       limit: 0,
     },
     timeout: SCRYFALL_IMAGE_DOWNLOAD_TIMEOUT,
-  })
+  }, maxBytes)
 
   if (response.statusCode >= 300 && response.statusCode < 400) {
     throw new Error('Redirect responses are not allowed for Scryfall images')
+  }
+
+  if (response.rawBody.length > maxBytes) {
+    throw new DownloadSizeLimitError(maxBytes)
   }
 
   return response.rawBody


### PR DESCRIPTION
## 概要

ZIP生成時の外部ダウンロードとメモリ使用量に、保守しやすい範囲で明示的な上限を設けました。

- Scryfall画像の取得を最大4並列に制限
- 1画像15 MiB、ZIP元画像合計200 MiBを上限にし、超過時は413を返却
- TTS結合結果を1チャンク100 MiB、合計300 MiBに制限
- 外部通信のタイムアウトとリトライなしを明示
- JSZipの最終バッファ生成をやめ、120秒上限つきのストリーム応答へ変更
- 同名ファイルへ決定的な連番を付け、上書きを防止
- 一部だけのZIPは返さず、取得失敗時はリクエスト全体を失敗させる

既存の入力件数上限（通常ZIP 100件、TTS 500件）はそのまま利用しています。

## 動作確認

- `pnpm test`（66 tests passed）
- `pnpm lint`（今回の追加警告なし。既存Vueファイルの5 warningsのみ）
- `pnpm build`
- ローカル起動後、実際のScryfall画像2件でZIPを取得
  - HTTP 200 / `application/zip`
  - 同名指定が `Black Lotus.png` と `Black Lotus-2.png` になることを確認

Closes #385
