### PR TITLE
fix: Hidden Face画像データをログへ出力しない

### DIFF
--- a/server/api/downloadTtsImages.post.ts
+++ b/server/api/downloadTtsImages.post.ts
@@ -47,10 +47,6 @@ export default defineEventHandler(async (event) => {
   })) ?? []
   const { hiddenImage } = body
 
-  if (hiddenImage) {
-    console.info('[downloadTtsImages] hiddenImage payload (base64):', hiddenImage)
-  }
-
   const payload = images.map((entry, index): MergePayloadItem => ({
     id: entry.id ?? `image-${index}`,
     imageUri: entry.imageUri,
@@ -105,7 +101,8 @@ export default defineEventHandler(async (event) => {
           cause: error,
         })
       }
-      throw createError({ statusCode: 502, statusMessage: 'Failed to merge images', cause: error })
+      // Got errors may retain request options, including the Hidden Face payload.
+      throw createError({ statusCode: 502, statusMessage: 'Failed to merge images' })
     }
   }
 

--- a/server/utils/validation.test.ts
+++ b/server/utils/validation.test.ts
@@ -7,6 +7,7 @@ import {
   downloadZipBodySchema,
   MAX_CARD_NAMES,
   MAX_DOWNLOAD_FILES,
+  MAX_HIDDEN_IMAGE_DATA_URL_LENGTH,
   MAX_TTS_IMAGES,
 } from './validation'
 
@@ -128,6 +129,13 @@ describe('downloadTtsImagesBodySchema', () => {
     })).toEqual({
       urls: ['https://example.test/card.png'],
     })
+  })
+
+  it('rejects a Hidden Face image above the size limit', () => {
+    expect(downloadTtsImagesBodySchema.safeParse({
+      images: [{ imageUri: 'https://example.test/card.png' }],
+      hiddenImage: `data:image/png;base64,${'A'.repeat(MAX_HIDDEN_IMAGE_DATA_URL_LENGTH)}`,
+    }).success).toBe(false)
   })
 
   it.each([


### PR DESCRIPTION
## 概要

Hidden Face画像のdata URL/Base64がアプリケーションログやエラー原因へ残らないようにしました。

- Base64ペイロード全体の `console.info` を削除
- Gotのエラーオブジェクトを502エラーの `cause` へ渡さないよう変更
- 既存のHidden Face画像サイズ上限（6 MiB）に上限超過テストを追加

## 原因

明示的なログ出力に加え、Gotのエラーオブジェクトが送信時のJSONを保持する可能性があり、汎用エラーログが `cause` を展開した場合にも画像データが漏れる余地がありました。

MIMEタイプ、data URL形式、最大サイズの検証は#383で導入済みのスキーマをそのまま利用しています。

## 動作確認

- `pnpm test`（67 tests passed）
- `pnpm lint`（今回の追加警告なし。既存Vueファイルの5 warningsのみ）
- `pnpm build`
- 不正なHidden FaceデータをAPIへ送信し、400になることを確認
- テスト用Base64文字列がレスポンス、サーバーログ、ビルド成果物に含まれないことを確認

Closes #386
