### PR TITLE
fix: 一致しないカードの誤置換を防止する

### DIFF
--- a/app/components/ScryModal.vue
+++ b/app/components/ScryModal.vue
@@ -96,8 +96,7 @@ const changeLang = () => {
 }
 
 const changeCard = () => {
-  updateCardsWithSelectedCard()
-  unset()
+  if (updateCardsWithSelectedCard()) unset()
 }
 
 const unset = () => {

--- a/app/composables/useCards.test.ts
+++ b/app/composables/useCards.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import type * as Scry from 'scryfall-sdk'
+import { replaceCardByOracleId } from './useCards'
+
+const card = (id: string, oracleId?: string): Scry.Card => ({
+  id,
+  oracle_id: oracleId,
+} as Scry.Card)
+
+describe('replaceCardByOracleId', () => {
+  it('does not replace a card when no card is selected', () => {
+    const cards = [card('first', 'oracle-1'), card('last', 'oracle-2')]
+
+    expect(replaceCardByOracleId(cards, undefined)).toBeUndefined()
+    expect(cards.map(({ id }) => id)).toEqual(['first', 'last'])
+  })
+
+  it('does not replace a card when the selected card has no oracle_id', () => {
+    const cards = [card('first', 'oracle-1'), card('last', 'oracle-2')]
+
+    expect(replaceCardByOracleId(cards, card('selected'))).toBeUndefined()
+    expect(cards.map(({ id }) => id)).toEqual(['first', 'last'])
+  })
+
+  it('does not replace a card when oracle_id does not match', () => {
+    const cards = [card('first', 'oracle-1'), card('last', 'oracle-2')]
+
+    expect(replaceCardByOracleId(cards, card('selected', 'oracle-3'))).toBeUndefined()
+    expect(cards.map(({ id }) => id)).toEqual(['first', 'last'])
+  })
+
+  it('replaces only the card with the matching oracle_id', () => {
+    const first = card('first', 'oracle-1')
+    const last = card('last', 'oracle-2')
+    const selected = card('selected', 'oracle-1')
+
+    const result = replaceCardByOracleId([first, last], selected)
+
+    expect(result).toEqual([selected, last])
+    expect(result?.[1]).toBe(last)
+  })
+})

--- a/app/composables/useCards.ts
+++ b/app/composables/useCards.ts
@@ -4,12 +4,25 @@ import type * as Scry from 'scryfall-sdk'
 export const addCard = (cards: Ref<Scry.Card[]>) => (card: Scry.Card) => {
   cards.value.push(card)
 }
-export const updateCardsWithSelectedCard = (cards: Ref<Scry.Card[]>, selectedCard: Ref<Scry.Card | undefined>) => () => {
-  const index = cards.value.findIndex((c) => {
-    return c.oracle_id === selectedCard.value?.oracle_id
-  })
 
-  if (selectedCard.value) cards.value.splice(index, 1, selectedCard.value)
+export const replaceCardByOracleId = (
+  cards: Scry.Card[],
+  selectedCard: Scry.Card | undefined,
+): Scry.Card[] | undefined => {
+  if (!selectedCard?.oracle_id) return undefined
+
+  const index = cards.findIndex(card => card.oracle_id === selectedCard.oracle_id)
+  if (index === -1) return undefined
+
+  return cards.map((card, cardIndex) => cardIndex === index ? selectedCard : card)
+}
+
+export const updateCardsWithSelectedCard = (cards: Ref<Scry.Card[]>, selectedCard: Ref<Scry.Card | undefined>) => () => {
+  const updatedCards = replaceCardByOracleId(cards.value, selectedCard.value)
+  if (!updatedCards) return false
+
+  cards.value = updatedCards
+  return true
 }
 export const updateCards = (cards: Ref<Scry.Card[]>) => (value: Scry.Card[]) => {
   cards.value = [...value]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,6 @@ export default defineConfig({
     },
   },
   test: {
-    include: ['server/**/*.test.ts'],
+    include: ['app/**/*.test.ts', 'server/**/*.test.ts'],
   },
 })


### PR DESCRIPTION
## 概要

カード画像の差し替え対象が見つからない場合に、末尾カードが誤って置換される問題を修正しました。

- `oracle_id`で安全に差し替える純粋ヘルパーを追加
- 未選択、`oracle_id`なし、一致なしの場合はカード一覧を変更せず失敗を返却
- 差し替え成功時だけモーダルを閉じるよう変更
- app配下の単体テストをVitest対象へ追加

## 原因

`findIndex()`が`-1`を返した場合も`splice(-1, ...)`を実行しており、JavaScriptの負数インデックスの挙動によって末尾カードが置換されていました。

## 動作確認

- `pnpm test`（71 tests passed）
- `pnpm lint`（エラーなし。既存Vueファイルの5 warningsのみ）
- `pnpm build`
- 未選択、`oracle_id`なし、一致なし、一致ありの単体テスト

Closes #387
