### PR TITLE
fix: collector numberを文字列のまま保持する

### DIFF
--- a/server/api/cards/byName.get.ts
+++ b/server/api/cards/byName.get.ts
@@ -19,7 +19,7 @@ export default defineEventHandler(async (event) => {
   try {
     const localizedCard = await scryfallBySet(
       card.set,
-      parseInt(card.collector_number),
+      card.collector_number,
       requestedLanguage,
     )
     return localizedCard

--- a/server/api/cards/byNames.post.ts
+++ b/server/api/cards/byNames.post.ts
@@ -41,7 +41,7 @@ export default defineEventHandler(async (event) => {
     try {
       const localizedCard = await scryfallBySet(
         card.set,
-        parseInt(card.collector_number),
+        card.collector_number,
         requestedLanguage,
       )
 

--- a/server/utils/scryfall.test.ts
+++ b/server/utils/scryfall.test.ts
@@ -1,0 +1,35 @@
+import type { Card } from 'scryfall-sdk'
+import * as Scry from 'scryfall-sdk'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { scryfallBySet } from './scryfall'
+
+vi.mock('scryfall-sdk', () => ({
+  Cards: {
+    bySet: vi.fn(),
+  },
+  setAgent: vi.fn(),
+}))
+
+describe('scryfallBySet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    delete (globalThis as typeof globalThis & {
+      __sibdScryfallRateLimit?: unknown
+    }).__sibdScryfallRateLimit
+  })
+
+  it.each(['123a', '123'])(
+    'passes collector number %s to the Scryfall SDK unchanged',
+    async (collectorNumber) => {
+      vi.mocked(Scry.Cards.bySet).mockResolvedValue({} as Card)
+
+      await scryfallBySet('set', collectorNumber, 'ja')
+
+      expect(Scry.Cards.bySet).toHaveBeenCalledWith(
+        'set',
+        collectorNumber,
+        'ja',
+      )
+    },
+  )
+})

--- a/server/utils/scryfall.ts
+++ b/server/utils/scryfall.ts
@@ -64,7 +64,7 @@ export const scryfallByName = (name: string, exact?: boolean) => {
 
 export const scryfallBySet = (
   set: string,
-  collectorNumber: number,
+  collectorNumber: string,
   language?: string,
 ) => {
   return withScryfallRateLimit(() =>


### PR DESCRIPTION
## 概要

ローカライズ版カード検索でcollector numberの文字列情報が失われないようにしました。

- 単体・バッチ取得経路の`parseInt(card.collector_number)`を削除
- `scryfallBySet()`のcollector numberを文字列として扱うよう変更
- 英数字の`123a`と数値形式の`123`がSDKへそのまま渡るテストを追加

## 原因

collector numberを数値へ変換していたため、`123a`が`123`になり、数値化できない値は`NaN`になっていました。Scryfall SDKは文字列を受け付けるため、この変換は不要でした。

## 動作確認

- `pnpm test`（69 tests passed）
- `pnpm lint`（エラーなし。既存Vueファイルの5 warningsのみ）
- `pnpm build`
- `123a`と`123`が文字列のままSDKへ渡る単体テスト

Closes #388
